### PR TITLE
Added an include guard for the header file

### DIFF
--- a/libketama/debian/changelog
+++ b/libketama/debian/changelog
@@ -1,3 +1,9 @@
+libketama (1.0-2) unstable; urgency=low
+
+  * Add include guard to ketama.h
+
+ -- Ricky Cormier <ricky@last.fm>  Mon, 13 Aug 2012 12:20:57 +0000
+
 libketama (1.0-1) unstable; urgency=low
 
   * Initial release

--- a/libketama/ketama.h
+++ b/libketama/ketama.h
@@ -26,6 +26,9 @@
 * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 
+#ifndef KETAMA_LIBKETAMA_KETAMA_H__
+#define KETAMA_LIBKETAMA_KETAMA_H__
+
 #include <sys/sem.h>    /* semaphore functions and structs. */
 
 #define MC_SHMSIZE  524288  // 512KB should be ample.
@@ -110,4 +113,6 @@ char* ketama_error();
 #ifdef __cplusplus /* If this is a C++ compiler, end C linkage */
 }
 #endif
+
+#endif // KETAMA_LIBKETAMA_KETAMA_H__
 


### PR DESCRIPTION
Hey RJ,

I was just playing about with libketama and realised there was no include guard so if you include the header in more than one translation unit you get a violation of the One Definition Rule. I've added a guard so if you'd like to pull it please feel free.

Cheers.

Ricky (Last FM / MIR)
