### PR TITLE
fixed build error: variable ‘ret’ set but not used

### DIFF
--- a/libketama/ketama.c
+++ b/libketama/ketama.c
@@ -270,14 +270,15 @@ read_server_definitions( char* filename, unsigned int* count, unsigned long* mem
     unsigned int lineno = 0;
     unsigned int numservers = 0;
     unsigned long memtotal = 0;
-    char * ret;
 
     FILE* fi = fopen( filename, "r" );
     while ( fi && !feof( fi ) )
     {
         char sline[128] = "";
 
-        ret = fgets( sline, 127, fi );
+        if (fgets( sline, 127, fi ) == NULL)
+            continue;
+
         lineno++;
 
         if ( strlen( sline ) < 2 || sline[0] == '#' )


### PR DESCRIPTION
This fixes a `variable ‘ret’ set but not used` under gcc 4.7.1:

```
ketama.c: In function ‘read_server_definitions’:
ketama.c:273:12: error: variable ‘ret’ set but not used [-Werror=unused-but-set-variable]
```
