### PR TITLE
Apparently the order of the flags matters (in Ubuntu at least)

### DIFF
--- a/libketama/Makefile
+++ b/libketama/Makefile
@@ -4,7 +4,7 @@ CFLAGS+=-fPIC -W -Wall -Werror
 build:
 	gcc $(CFLAGS) -O3 -c md5.c
 	gcc $(CFLAGS) -O3 -c ketama.c
-	gcc -shared -Wl,-soname,libketama.so.1 -lm -o libketama.so.1 ketama.o md5.o
+	gcc -shared -Wl,-soname,libketama.so.1 -o libketama.so.1 ketama.o md5.o -lm
 
 debug:
 	gcc $(CFLAGS) -g -DDEBUG -o md5-debug.o -c md5.c
@@ -12,7 +12,7 @@ debug:
 	gcc -g -shared -Wl,-soname,libketama.so.1 -o libketama.so.1 ketama-debug.o md5-debug.o -lm
 
 test: build
-	LD_LIBRARY_PATH=. gcc $(CFLAGS) -I. -O3 -lm -o ketama_test ketama_test.c ./libketama.so.1
+	LD_LIBRARY_PATH=. gcc $(CFLAGS) -I. -O3 -o ketama_test ketama_test.c ./libketama.so.1 -lm
 	@./test.sh
 	@./downed_server_test.sh
 

--- a/libketama/Makefile
+++ b/libketama/Makefile
@@ -9,7 +9,7 @@ build:
 debug:
 	gcc $(CFLAGS) -g -DDEBUG -o md5-debug.o -c md5.c
 	gcc $(CFLAGS) -g -DDEBUG -o ketama-debug.o -c ketama.c
-	gcc -g -shared -Wl,-soname,libketama.so.1 -lm -o libketama.so.1 ketama-debug.o md5-debug.o
+	gcc -g -shared -Wl,-soname,libketama.so.1 -o libketama.so.1 ketama-debug.o md5-debug.o -lm
 
 test: build
 	LD_LIBRARY_PATH=. gcc $(CFLAGS) -I. -O3 -lm -o ketama_test ketama_test.c ./libketama.so.1


### PR DESCRIPTION
Ubuntu 12.04 compile of libketama was failing with the following message:

make test
gcc -fPIC -W -Wall -Werror -O3 -c md5.c
gcc -fPIC -W -Wall -Werror -O3 -c ketama.c
gcc -lm -shared -Wl,-soname,libketama.so.1 -o libketama.so.1 ketama.o md5.o
LD_LIBRARY_PATH=. gcc -lm -fPIC -W -Wall -Werror -I. -O3 -o ketama_test ketama_test.c ./libketama.so.1
./libketama.so.1: undefined reference to `floorf'
collect2: ld returned 1 exit status
make: **\* [test] Error 1

Once the -lm was moved in the test, all worked fine.
