### PR TITLE
fixed tracking mapped shm segments

### DIFF
--- a/libketama/ketama.c
+++ b/libketama/ketama.c
@@ -574,12 +574,12 @@ ketama_roll( ketama_continuum* contptr, char* filename )
             return 0;
         }
 
+        track_shm_data(data);
+
         (*contptr)->numpoints = *data;
         (*contptr)->modtime = ++data;
         (*contptr)->array = data + sizeof( void* );
         fmodtime = (time_t*)( (*contptr)->modtime );
-
-        track_shm_data(data);
     }
 
     return 1;


### PR DESCRIPTION
The pointer to the mapped segment is modified before being tracked. As a result, the wrong address is being unmapped in ketama_smoke.

On systems with low shm-related limits, this causes ketama_roll to fail after a few calls (too many mapped segments, too many mapped pages, etc)
