### PR TITLE
docs: fix simple typo, occured -> occurred

### DIFF
--- a/libketama/ketama.h
+++ b/libketama/ketama.h
@@ -107,7 +107,7 @@ unsigned int ketama_hashi( char* inString );
 void ketama_md5_digest( char* inString, unsigned char md5pword[16] );
 
 /** \brief Error method for error checking.
-  * \return The latest error that occured. */
+  * \return The latest error that occurred. */
 char* ketama_error();
 
 #ifdef __cplusplus /* If this is a C++ compiler, end C linkage */


### PR DESCRIPTION
There is a small typo in libketama/ketama.h.

Should read `occurred` rather than `occured`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md